### PR TITLE
Change default URI for all Hawtio templates

### DIFF
--- a/webtest/components/models/hawtio/addresses_page.py
+++ b/webtest/components/models/hawtio/addresses_page.py
@@ -10,7 +10,7 @@ from webtest.common.selector import Selector
 
 
 class HawtioAddressesPage(HawtioArtemisLayoutTwoPage):
-    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="hawtio/artemis/addresses", *args, **kw):
+    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="console/artemis/addresses", *args, **kw):
         super(HawtioAddressesPage, self).__init__(protocol, host, port, uri, *args, **kw)
 
     def _create_template(self):

--- a/webtest/components/models/hawtio/artemis_layout_one.py
+++ b/webtest/components/models/hawtio/artemis_layout_one.py
@@ -10,7 +10,7 @@ from webtest.common.http import Constants
 
 
 class HawtioArtemisLayoutOnePage(PageModel):
-    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="hawtio/artemis", *args, **kw):
+    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="console/artemis", *args, **kw):
         super(HawtioArtemisLayoutOnePage, self).__init__(protocol, host, port, uri, *args, **kw)
 
     def _create_template(self):

--- a/webtest/components/models/hawtio/artemis_layout_two.py
+++ b/webtest/components/models/hawtio/artemis_layout_two.py
@@ -10,7 +10,7 @@ from webtest.common.http import Constants
 
 
 class HawtioArtemisLayoutTwoPage(PageModel):
-    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="hawtio/artemis", *args, **kw):
+    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="console/artemis", *args, **kw):
         super(HawtioArtemisLayoutTwoPage, self).__init__(protocol, host, port, uri, *args, **kw)
 
     def _create_template(self):

--- a/webtest/components/models/hawtio/attributes_page.py
+++ b/webtest/components/models/hawtio/attributes_page.py
@@ -10,7 +10,7 @@ from webtest.common.http import Constants
 
 
 class HawtioAttributesPage(HawtioArtemisLayoutOnePage):
-    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="hawtio/jmx/attributes", *args, **kw):
+    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="console/jmx/attributes", *args, **kw):
         super(HawtioAttributesPage, self).__init__(protocol, host, port, uri, *args, **kw)
 
     def _create_template(self):

--- a/webtest/components/models/hawtio/connections_page.py
+++ b/webtest/components/models/hawtio/connections_page.py
@@ -10,7 +10,7 @@ from webtest.common.selector import Selector
 
 
 class HawtioConnectionsPage(HawtioArtemisLayoutTwoPage):
-    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="hawtio/artemis/connections", *args, **kw):
+    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="console/artemis/connections", *args, **kw):
         super(HawtioConnectionsPage, self).__init__(protocol, host, port, uri, *args, **kw)
 
     def _create_template(self):

--- a/webtest/components/models/hawtio/consumers_page.py
+++ b/webtest/components/models/hawtio/consumers_page.py
@@ -10,7 +10,7 @@ from webtest.common.selector import Selector
 
 
 class HawtioConsumersPage(HawtioArtemisLayoutTwoPage):
-    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="hawtio/artemis/consumers", *args, **kw):
+    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="console/artemis/consumers", *args, **kw):
         super(HawtioConsumersPage, self).__init__(protocol, host, port, uri, *args, **kw)
 
     def _create_template(self):

--- a/webtest/components/models/hawtio/create_address_page.py
+++ b/webtest/components/models/hawtio/create_address_page.py
@@ -10,7 +10,7 @@ from webtest.common.http import Constants
 
 
 class HawtioCreateAddressPage(HawtioArtemisLayoutOnePage):
-    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="hawtio/artemis/createAddress", *args, **kw):
+    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="console/artemis/createAddress", *args, **kw):
         super(HawtioCreateAddressPage, self).__init__(protocol, host, port, uri, *args, **kw)
 
     def _create_template(self):

--- a/webtest/components/models/hawtio/create_queue_page.py
+++ b/webtest/components/models/hawtio/create_queue_page.py
@@ -10,7 +10,7 @@ from webtest.common.selector import Selector
 
 
 class HawtioQueueCreatePage(HawtioArtemisLayoutOnePage):
-    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="/hawtio/artemis/createQueue", *args, **kw):
+    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="/console/artemis/createQueue", *args, **kw):
         super(HawtioQueueCreatePage, self).__init__(protocol, host, port, uri, *args, **kw)
 
     def _create_template(self):

--- a/webtest/components/models/hawtio/login_page.py
+++ b/webtest/components/models/hawtio/login_page.py
@@ -10,7 +10,7 @@ from webtest.common.http import Constants
 
 
 class HawtioLoginPageNS(PageModel):
-    def __init__(self,protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="hawtio", *arg, **kw):
+    def __init__(self,protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="console", *arg, **kw):
         super(HawtioLoginPageNS, self).__init__(protocol, host, port, uri, *arg, **kw)
 
     def _create_template(self):

--- a/webtest/components/models/hawtio/operations_page.py
+++ b/webtest/components/models/hawtio/operations_page.py
@@ -10,7 +10,7 @@ from webtest.common.selector import Selector
 
 
 class HawtioAttributesPage(HawtioArtemisLayoutOnePage):
-    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="hawtio/jmx/operations", *args, **kw):
+    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="console/jmx/operations", *args, **kw):
         super(HawtioAttributesPage, self).__init__(protocol, host, port, uri, *args, **kw)
 
     def _create_template(self):

--- a/webtest/components/models/hawtio/producers_page.py
+++ b/webtest/components/models/hawtio/producers_page.py
@@ -10,7 +10,7 @@ from webtest.common.selector import Selector
 
 
 class HawtioProducersPage(HawtioArtemisLayoutTwoPage):
-    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="hawtio/artemis/producers", *args, **kw):
+    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="console/artemis/producers", *args, **kw):
         super(HawtioProducersPage, self).__init__(protocol, host, port, uri, *args, **kw)
 
     def _create_template(self):

--- a/webtest/components/models/hawtio/queues_page.py
+++ b/webtest/components/models/hawtio/queues_page.py
@@ -10,7 +10,7 @@ from webtest.common.selector import Selector
 
 
 class HawtioQueuesPage(HawtioArtemisLayoutTwoPage):
-    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="hawtio/artemis/queues", *args, **kw):
+    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="console/artemis/queues", *args, **kw):
         super(HawtioQueuesPage, self).__init__(protocol, host, port, uri, *args, **kw)
 
     def _create_template(self):

--- a/webtest/components/models/hawtio/sessions_page.py
+++ b/webtest/components/models/hawtio/sessions_page.py
@@ -10,7 +10,7 @@ from webtest.common.selector import Selector
 
 
 class HawtioSessionsPage(HawtioArtemisLayoutTwoPage):
-    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="hawtio/artemis/sessions", *args, **kw):
+    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="console/artemis/sessions", *args, **kw):
         super(HawtioSessionsPage, self).__init__(protocol, host, port, uri, *args, **kw)
 
     def _create_template(self):

--- a/webtest/components/models/hawtio/welcome_page.py
+++ b/webtest/components/models/hawtio/welcome_page.py
@@ -10,7 +10,7 @@ from webtest.common.http import Constants
 
 
 class HawtioWelcomePage(PageModel):
-    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="hawtio/welcome", *arg, **kw):
+    def __init__(self, protocol=Constants.PROTOCOL_HTTP, host="rhel7", port=8161, uri="console/welcome", *arg, **kw):
         super(HawtioWelcomePage, self).__init__(protocol, host, port, uri, *arg, **kw)
 
     def _create_template(self):

--- a/webtest/tests/scenarios/hawtio/address_and_queue_handling.py
+++ b/webtest/tests/scenarios/hawtio/address_and_queue_handling.py
@@ -38,7 +38,7 @@ login_page = HawtioLoginPageNS(host=template_hostname, port=template_port)
 
 models = [
     login_page,
-    login_page.derive_template(name="HawtioAlternativeLogin", uri="hawtio/login"),
+    login_page.derive_template(name="HawtioAlternativeLogin", uri="console/login"),
     HawtioWelcomePage(host=template_hostname, port=template_port),
     HawtioAttributesPage(host=template_hostname, port=template_port),
     HawtioCreateAddressPage(host=template_hostname, port=template_port),


### PR DESCRIPTION
Because in 7.1.0 broker URL has changed, so should default valuest for
its templates.